### PR TITLE
feat: allow pass libyear flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ It will create or update json files in the data directory. You can then initiali
 
 ### Configuration
 
-The `repositories.txt` file contains the git repositories you want to track. Put one repository per line with the full URL to access it.
+The `repositories.txt` file contains the git repositories you want to track. Put one repository per line with the full URL to access it and you can add libyear flags in second option.
 
     https://github.com/Dependency-Drift-Tracker/dependency-drift-tracker
-    https://github.com/Dependency-Drift-Tracker/dependency-drift-tracker-action
+    https://github.com/Dependency-Drift-Tracker/dependency-drift-tracker-action,{ "dev": true }
 
 If your package.json is in a subdirectory, you can use the `#` to specify the path:
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,10 +8,12 @@ export function parseFile(content) {
 }
 
 export function parseRepositoryLine(line) {
-  const [repository, path] = line.split('#');
+  const [url, flags] = line.split(',');
+  const [repository, path] = url.split('#');
   return {
     repository,
     path: path || '',
+    libyearFlags: JSON.parse(flags || '{}'),
   };
 }
 

--- a/tests/index_test.js
+++ b/tests/index_test.js
@@ -13,14 +13,24 @@ describe('#parseRepositoryLine', function() {
   it('parse simple repository', function() {
     expect(parseRepositoryLine('https://github.com/1024pix/pix.git')).to.deep.equal({
       repository: 'https://github.com/1024pix/pix.git',
-      path: ''
+      path: '',
+      libyearFlags: {}
     })
   });
 
   it('parse repository with a sub directory', function() {
     expect(parseRepositoryLine('https://github.com/1024pix/pix.git#test')).to.deep.equal({
       repository: 'https://github.com/1024pix/pix.git',
-      path: 'test'
+      path: 'test',
+      libyearFlags: {}
+    })
+  });
+
+  it('parse repository with a sub directory and libyear flags', function() {
+    expect(parseRepositoryLine('https://github.com/1024pix/pix.git#test,{ "dev":true }')).to.deep.equal({
+      repository: 'https://github.com/1024pix/pix.git',
+      path: 'test',
+      libyearFlags: { dev: true}
     })
   });
 });
@@ -29,17 +39,19 @@ describe('#parseFile', function() {
   it('parse the file', function() {
     const content = `
 https://github.com/1024pix/pix.git#api
-https://github.com/1024pix/pix.git#mon-pix
+https://github.com/1024pix/pix.git#mon-pix, {"dev":true}
 # comment line
 `;
     expect(parseFile(content)).to.deep.equal([
       {
         repository: 'https://github.com/1024pix/pix.git',
         path: 'api',
+        libyearFlags: {}
       },
       {
         repository: 'https://github.com/1024pix/pix.git',
-        path: 'mon-pix'
+        path: 'mon-pix',
+        libyearFlags: { dev: true }
       },
     ])
   });


### PR DESCRIPTION
Depuis la version ` v0.4.1.`, nous n'avons plus de résultat sur certains repository qui n'ont que des devs dependencies : 
<img width="1986" height="436" alt="Screenshot 2025-07-25 at 14 59 09" src="https://github.com/user-attachments/assets/a5910752-29ad-410d-88a8-7f51fb08c4a5" />

Nous avons l'impression que depuis la v0.9.0 (n'ayant plus l'historique complet) de libyear lorsque le flag dev n'est pas fourni alors les devDependencies ne remontent plus (cf. https://github.com/jdanil/libyear/blob/8b7fd335156899baa17d411ffdbdb63108a5f0ab/src/fetch/dependencies.ts#L72 et https://github.com/jdanil/libyear/blob/8b7fd335156899baa17d411ffdbdb63108a5f0ab/src/fetch/dependencies.ts#L78).

Nous proposons alors de pouvoir choisir directement les options de libyear à lui passer par ligne de repository pour être le plus modulable possible. 